### PR TITLE
Update render-build.sh

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -5,4 +5,4 @@ set -o errexit
 bundle install
 ./bin/rails assets:precompile
 ./bin/rails assets:clean
-./bin/rails db:reset
+./bin/rails db:reset DISABLE_DATABASE_ENVIRONMENT_CHECK=1


### PR DESCRIPTION
disabling prod env check. This means each build will reset the database each time until this gets commented out or removed.

Otherwise can have rails db:migrate, then rails db:seed when needed.